### PR TITLE
fix: resolve modules from cwd

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,4 +1,3 @@
 module.exports = {
     preset: "@forsakringskassan/jest-config",
-    modulePaths: ["<rootDir>/fixtures"],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@forsakringskassan/eslint-config-jest": "^11.4.2",
         "@forsakringskassan/jest-config": "^29.6.0",
         "@forsakringskassan/prettier-config": "^2.1.1",
+        "@jest/globals": "^29.7.0",
         "esbuild": "^0.24.0",
         "husky": "^9.1.7",
         "jest": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@forsakringskassan/eslint-config-jest": "^11.4.2",
     "@forsakringskassan/jest-config": "^29.6.0",
     "@forsakringskassan/prettier-config": "^2.1.1",
+    "@jest/globals": "^29.7.0",
     "esbuild": "^0.24.0",
     "husky": "^9.1.7",
     "jest": "^29.7.0",

--- a/src/importer.js
+++ b/src/importer.js
@@ -24,7 +24,9 @@ export const moduleImporter = {
         for (const variant of search) {
             try {
                 const moduleName = path.posix.join(directory, variant);
-                const resolved = require.resolve(moduleName);
+                const resolved = require.resolve(moduleName, {
+                    paths: [process.cwd()],
+                });
                 return new URL(pathToFileURL(resolved));
             } catch (err) {
                 if (err.code !== "MODULE_NOT_FOUND") {

--- a/src/importer.spec.js
+++ b/src/importer.spec.js
@@ -1,8 +1,13 @@
 import fs from "node:fs";
+import process from "node:process";
 import { compileString } from "sass";
+import { jest } from "@jest/globals";
 import { moduleImporter } from "./importer";
 
 it("should be able to transform scss", () => {
+    const spyProcess = jest.spyOn(process, "cwd");
+    spyProcess.mockReturnValue("../fixtures/");
+
     const result = compileString(
         fs.readFileSync("./fixtures/main.scss", "utf-8"),
         {


### PR DESCRIPTION
Interna tester har tidigare visat att koden inte funkar när `npm link` nyttjas, vilket gett upphov till följande lösning:
https://github.com/Forsakringskassan/docs-generator/commit/59f3753286f1b786aab28054652b5ea9faec6342

Detta är ett provskott till en mer "native"-fix, men behöver testas innan merge. 

