### PR TITLE
Skip post pack check

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   ],
   "scripts": {
     "build": "node build.mjs",
-    "postpack": "npm-pkg-lint",
     "eslint": "eslint .",
     "eslint:fix": "eslint . --fix",
     "lint": "run-s eslint prettier:check",


### PR DESCRIPTION
Bygget fallerade inatt pga:
https://github.com/Forsakringskassan/sass-module-importer/actions/runs/12819905607

```
[12:10:58 AM] [semantic-release] › ℹ  Start step "publish" of plugin "@semantic-release/npm"
[12:10:58 AM] [semantic-release] [@semantic-release/npm] › ℹ  Publishing version 1.0.0 to npm registry on dist-tag latest

> @forsakringskassan/sass-module-importer@1.0.0 prepare
> husky

@forsakringskassan/sass-module-importer@1.0.0 postpack
npm-pkg-lint

"/home/runner/work/sass-module-importer/sass-module-importer/forsakringskassan-sass-module-importer-1.0.0.tgz" does not exist, did you forget to run `npm pack'?

```

Jag misstänker att det är fel läge att köra npm-pkg-lint i detta läget, detta pga att `npm-pkg-lint`, letar efter tarball version 1.0.0, men den fil finns inte pga att semantic release inte kört sitt race än.

Tänker mig att workflow-filen som specifikt testar pkg-lint räcker, det behövs inte göras i release-kedjan också.