### PR TITLE
fix: should be able to find files starting with underline

### DIFF
--- a/fixtures/node_modules/@forsakringskassan/a-fancy-package/src/_reset.scss
+++ b/fixtures/node_modules/@forsakringskassan/a-fancy-package/src/_reset.scss
@@ -1,0 +1,3 @@
+.reset {
+    color: inherit;
+}

--- a/src/__snapshots__/importer.spec.js.snap
+++ b/src/__snapshots__/importer.spec.js.snap
@@ -44,6 +44,10 @@ body {
   color: greenyellow;
 }
 
+.reset {
+  color: inherit;
+}
+
 .foo {
   color: green;
 }"

--- a/src/importer.js
+++ b/src/importer.js
@@ -18,7 +18,7 @@ export const moduleImporter = {
         }
 
         const packageName = getPackageNameFromPath(findUrl);
-        const fileName = findUrl.split(packageName)[1];
+        const filePath = findUrl.split(packageName)[1];
         const packagePath = resolvePackagePath(packageName, process.cwd());
 
         /* Validate if existing package */
@@ -34,7 +34,7 @@ export const moduleImporter = {
 
         /* Check exports */
         try {
-            const match = exports(packageJson, fileName.substring(1), {
+            const match = exports(packageJson, filePath.substring(1), {
                 conditions: ["sass"],
             });
             if (match && match.length === 1) {
@@ -47,7 +47,7 @@ export const moduleImporter = {
         }
 
         /* Check main fields (only applies if only package path is given) */
-        if (!fileName) {
+        if (!filePath) {
             const match = legacy(packageJson, { fields: ["sass", "main"] });
             if (match) {
                 return new URL(
@@ -57,6 +57,9 @@ export const moduleImporter = {
         }
 
         /* Direct link */
+        const directory = path.dirname(filePath);
+        const fileName = path.basename(filePath);
+
         const search = [
             `${fileName}.css`,
             `${fileName}.scss`,
@@ -66,7 +69,11 @@ export const moduleImporter = {
 
         for (const variant of search) {
             try {
-                const moduleName = path.posix.join(moduleDirectory, variant);
+                const moduleName = path.posix.join(
+                    moduleDirectory,
+                    directory,
+                    variant,
+                );
                 const resolved = require.resolve(moduleName);
                 return new URL(pathToFileURL(resolved));
             } catch (err) {

--- a/src/importer.spec.js
+++ b/src/importer.spec.js
@@ -26,6 +26,7 @@ it("should be able to transform scss using package without exports and main fiel
     const append = `
         @use "@forsakringskassan/a-fancy-package/src/default.scss";
         @use "@forsakringskassan/a-fancy-package/src/extra.scss";
+        @use "@forsakringskassan/a-fancy-package/src/reset";
     `;
     expect(init(append)).toMatchSnapshot();
 });


### PR DESCRIPTION
Should be able to find following variants.

```
foo/bar/baz.sass
foo/bar/baz.scss
foo/bar/_baz.sass
foo/bar/_baz.scss
```

Which have been broken since version v1.1.0.