### PR TITLE
fix: should be able to import _index files from directories

### DIFF
--- a/fixtures/node_modules/@forsakringskassan/a-fancy-package/src/directory/_index.scss
+++ b/fixtures/node_modules/@forsakringskassan/a-fancy-package/src/directory/_index.scss
@@ -1,0 +1,3 @@
+.directory {
+    color: pink;
+}

--- a/src/__snapshots__/importer.spec.js.snap
+++ b/src/__snapshots__/importer.spec.js.snap
@@ -10,6 +10,16 @@ exports[`should be able to import scss file with same name as package name 1`] =
 }"
 `;
 
+exports[`should be able to transform directory imports (index files) 1`] = `
+".directory {
+  color: pink;
+}
+
+.foo {
+  color: green;
+}"
+`;
+
 exports[`should be able to transform scss using package with exports 1`] = `
 "span {
   color: pink;

--- a/src/importer.js
+++ b/src/importer.js
@@ -82,6 +82,7 @@ export const moduleImporter = {
             `${fileName}.scss`,
             `_${fileName}.scss`,
             `${fileName}`,
+            `${fileName}/_index.scss`,
         ];
 
         for (const variant of search) {

--- a/src/importer.spec.js
+++ b/src/importer.spec.js
@@ -72,3 +72,10 @@ it("should be able to transform scss when package contains reference to itself",
     `;
     expect(init(append)).toMatchSnapshot();
 });
+
+it("should be able to transform directory imports (index files)", () => {
+    const append = `
+        @use "~@forsakringskassan/a-fancy-package/src/directory";
+    `;
+    expect(init(append)).toMatchSnapshot();
+});


### PR DESCRIPTION
https://sass-lang.com/documentation/at-rules/import/#index-files

`If you write an _index.scss or _index.sass in a folder, when the folder itself is imported that file will be loaded in its place.`

This plugin do not support sass extension right now, maybe that needs to be implemented later? 